### PR TITLE
Use `.format()` in `BackendError.__str__()`

### DIFF
--- a/groupy/exc.py
+++ b/groupy/exc.py
@@ -8,7 +8,7 @@ class BackendError(Error):
         self.server = server
 
     def __str__(self):
-        return "({}:{}) - {}" % (
+        return "({}:{}) - {}".format(
             self.server.hostname, self.server.port, self.message
         )
 


### PR DESCRIPTION
Previously, we were using old-style `%` formatting with a new-style format
string. This meant that printing a `BackendError` would itself raise a
`TypeError`.