### PR TITLE
Client support for API tokens

### DIFF
--- a/groupy/client.py
+++ b/groupy/client.py
@@ -76,10 +76,11 @@ class Groupy(object):
             **kwargs
         )
         try:
-            out = json.loads(http_client.fetch(url, **{
-                "connect_timeout": self.timeout,
-                "request_timeout": self.timeout,
-            }).body)
+            out = json.loads(http_client.fetch(
+                url,
+                connect_timeout=self.timeout,
+                request_timeout=self.timeout,
+            ).body)
         except HTTPError as err:
             if err.code == 599:
                 raise exc.BackendConnectionError(err.message, server)

--- a/groupy/client.py
+++ b/groupy/client.py
@@ -1,3 +1,4 @@
+import urllib
 from collections import namedtuple
 import json
 from threading import Lock
@@ -115,3 +116,12 @@ class Groupy(object):
             self.checkpoint = new_checkpoint
 
         return out
+
+    def authenticate(self, token):
+        return self._try_fetch(
+            '/token/validate',
+            method='POST',
+            body=urllib.urlencode({
+                "token": token,
+            })
+        )

--- a/groupy/collations.py
+++ b/groupy/collations.py
@@ -11,7 +11,7 @@ class Collection(object):
         path = "/{}".format(self.name)
         if resource:
             path += "/{}".format(resource)
-        response = self.client._try_get(path)
+        response = self.client._try_fetch(path)
         self._check_error(response)
         return response
 


### PR DESCRIPTION
```
In [1]: from groupy.client import Groupy

In [2]: cl = Groupy("127.0.0.1:8990")

In [3]: cl.authenticate('admin@example.com/zzzz:fe1050204947f574fd2d7762306b7bf2bf50e5f2')
Out[3]: 
{u'checkpoint': 13,
 u'checkpoint_time': 1456264031,
 u'data': {u'act_as_owner': True,
  u'identity': u'admin@example.com/zzzz',
  u'owner': u'admin@example.com',
  u'valid': True},
 u'status': u'ok'}
```

Also some misc fixes. 