### PR TITLE
Move fetch kwargs to HttpRequest object

### DIFF
--- a/groupy/client.py
+++ b/groupy/client.py
@@ -75,14 +75,12 @@ class Groupy(object):
         server = self.backends.server
         url = HTTPRequest(
             "http://{}:{}{}".format(server.hostname, server.port, path),
+            connect_timeout=self.timeout,
+            request_timeout=self.timeout,
             **kwargs
         )
         try:
-            out = json.loads(http_client.fetch(
-                url,
-                connect_timeout=self.timeout,
-                request_timeout=self.timeout,
-            ).body)
+            out = json.loads(http_client.fetch(url).body)
         except HTTPError as err:
             if err.code == 599:
                 raise exc.BackendConnectionError(err.message, server)


### PR DESCRIPTION
Tornado doesn't support kwargs with fetch when the url is a HTTPRequest. This used to fail silently but with recent versions of tornado (I'm on 4.4.1) it throws an error.