### PR TITLE
Support new service accounts, add password support

### DIFF
--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -4,6 +4,35 @@ from groupy.client import HTTPClient
 
 
 @pytest.fixture
+def service_account_response(request):
+    return {
+        u'checkpoint': 10,
+        u'checkpoint_time': 1000,
+        u'data': {
+            u'groups': {},
+            u'permissions': [{
+                u'argument': u'shell',
+                u'granted_on': 1452796706.894347,
+                u'permission': u'sudo',
+            }],
+            u'user': {
+                u'enabled': True,
+                u'metadata': [],
+                u'name': u'service@a.co',
+                u'public_keys': [],
+                u'role_user': False,
+                u'service_account': {
+                    u'description': u'Some service account',
+                    u'machine_set': u'shell',
+                    u'owner': u'security-team',
+                },
+            }
+        },
+        u'status': u'ok',
+    }
+
+
+@pytest.fixture
 def user_response(request):
     return {
         u'checkpoint': 10,

--- a/tests/test_resources.py
+++ b/tests/test_resources.py
@@ -1,0 +1,29 @@
+import json
+
+from mock import Mock, patch
+
+from fixtures import service_account_response
+from groupy.client import Groupy, HTTPClient
+from groupy.resources import MappedPermission
+
+
+def test_service_account(service_account_response):
+    res = Mock()
+    res.body = json.dumps(service_account_response)
+    mock_fetch = Mock()
+    mock_fetch.side_effect = [res]
+    with patch.object(HTTPClient, 'fetch', mock_fetch):
+        client = Groupy(['localhost:8000'])
+        service = client.users.get('service@a.co')
+        assert service.enabled
+        assert service.groups == {}
+        assert service.passwords == []
+        assert service.permissions == [MappedPermission(
+            permission=u'sudo',
+            argument=u'shell',
+            granted_on=1452796706.894347,
+            distance=None,
+            path=None,
+        )]
+        expected = service_account_response['data']['user']['service_account']
+        assert service.service_account == expected


### PR DESCRIPTION
This is a slightly hacky approach that just exposes the new
service account metadata if present and rewrites service account
permissions to `None` the fields that they don't have.  A better
long-term approach would polymorphism and return ServiceAccount
objects alongside User objects, but that raises various
complications and is deferred for future work.

While updating the list of supported fields, add support for
passwords to match the current graph API.