### PR TITLE
Fix flake8 warnings

### DIFF
--- a/groupy/client.py
+++ b/groupy/client.py
@@ -1,13 +1,15 @@
-import urllib
-from collections import namedtuple
 import json
+import urllib
+
+from collections import namedtuple
 from threading import Lock
 
 from clowncar.backends import Backends
 from tornado.httpclient import HTTPClient, HTTPError, HTTPRequest
 
 from . import exc
-from .collations import Users, Groups, Permissions, ServiceAccounts
+from .collations import Groups, Permissions, ServiceAccounts, Users
+
 
 Checkpoint = namedtuple('Checkpoint', ['checkpoint', 'checkpoint_time'])
 

--- a/groupy/collations.py
+++ b/groupy/collations.py
@@ -1,5 +1,5 @@
 from . import exc
-from .resources import User, Group, Permission, ServiceAccount
+from .resources import Group, Permission, ServiceAccount, User
 
 
 class Collection(object):

--- a/groupy/servers.py
+++ b/groupy/servers.py
@@ -1,6 +1,8 @@
-from clowncar.server import Server
-from threading import Lock
 import time
+
+from threading import Lock
+
+from clowncar.server import Server
 
 
 class ServersFileLoader(object):

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,7 @@
 [aliases]
 test=pytest
+
 [flake8]
+import-order-style = google
 max-line-length = 100
 ignore = E128

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,8 @@ kwargs = {
         "tornado>=3.2",
     ],
     "setup_requires": [
-        "flake8==2.5.0",
+        "flake8==2.5.4",
+        "flake8-import-order==0.8",
         "pytest-runner",
     ],
     "tests_require": [


### PR DESCRIPTION
Resolves all flake8 warnings from `python setup.py flake8`, all of
which were import ordering and formatting issues.