### PR TITLE
Make flake8 and pytest dependencies conditional

### DIFF
--- a/groupy/client.py
+++ b/groupy/client.py
@@ -1,6 +1,5 @@
 import json
 import urllib
-
 from collections import namedtuple
 from threading import Lock
 

--- a/groupy/servers.py
+++ b/groupy/servers.py
@@ -1,5 +1,4 @@
 import time
-
 from threading import Lock
 
 from clowncar.server import Server

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,7 @@
 [aliases]
-test=pytest
+test = pytest
 
 [flake8]
-import-order-style = google
+import-order-style = smarkets
 max-line-length = 100
 ignore = E128

--- a/setup.py
+++ b/setup.py
@@ -1,8 +1,16 @@
 #!/usr/bin/env python
 
+import sys
+
 from setuptools import setup
 
 execfile("groupy/version.py")
+
+setup_requires = []
+if "flake8" in sys.argv:
+    setup_requires += ["flake8==2.5.0", "flake8-import-order==0.8"]
+if "test" in sys.argv:
+    setup_requires += ["pytest-runner"]
 
 kwargs = {
     "name": "groupy",
@@ -15,13 +23,12 @@ kwargs = {
         "clowncar",
         "tornado>=3.2",
     ],
-    "setup_requires": [
-        "flake8==2.5.4",
-        "flake8-import-order==0.8",
-        "pytest-runner",
-    ],
+    "setup_requires": setup_requires,
     "tests_require": [
+        "flake8==2.5.0",
+        "flake8-import-order==0.8",
         "pytest>=2.6",
+        "pytest-runner",
         "mock>=1.0",
     ],
     "url": "https://github.com/dropbox/groupy",

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ execfile("groupy/version.py")
 
 setup_requires = []
 if "flake8" in sys.argv:
-    setup_requires += ["flake8==2.5.0", "flake8-import-order==0.8"]
+    setup_requires += ["flake8>=3.5.0", "flake8-import-order>=0.16"]
 if "test" in sys.argv:
     setup_requires += ["pytest-runner"]
 
@@ -25,8 +25,8 @@ kwargs = {
     ],
     "setup_requires": setup_requires,
     "tests_require": [
-        "flake8==2.5.0",
-        "flake8-import-order==0.8",
+        "flake8>=3.5.0",
+        "flake8-import-order>=0.16",
         "pytest>=2.6",
         "pytest-runner",
         "mock>=1.0",


### PR DESCRIPTION
Rather than unconditionally adding flake8, flake8-import-order,
and pytest-runner to setup_requires, only add them if invoked
with arguments that would require them.  This allows those
dependencies to be omitted in environments that only care about
installing and running the code.

Fixes #22