### PR TITLE
replace execfile

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ import sys
 
 from setuptools import setup
 
-execfile("groupy/version.py")
+exec(open("groupy/version.py").read())
 
 setup_requires = []
 if "flake8" in sys.argv:


### PR DESCRIPTION
execfile isn't available in python3, this should be the same behavior. @lfaraone 