### PR TITLE
Handle connection refused errors when fetching

### DIFF
--- a/groupy/client.py
+++ b/groupy/client.py
@@ -1,6 +1,9 @@
+import errno
 import json
 import logging
+import socket
 import urllib
+
 from collections import namedtuple
 from threading import Lock
 
@@ -89,6 +92,10 @@ class Groupy(object):
                     raise exc.BackendIntegrityError(err.message, server)
             except (ValueError, TypeError):
                 raise exc.BackendIntegrityError(err.message, server)
+        except socket.error as err:
+            if err.errno == errno.ECONNREFUSED:
+                raise exc.BackendConnectionError("socket error (Connection Refused)", server)
+            raise
 
         with self._lock:
             new_checkpoint = Checkpoint(

--- a/groupy/client.py
+++ b/groupy/client.py
@@ -3,7 +3,6 @@ import json
 import logging
 import socket
 import urllib
-
 from collections import namedtuple
 from threading import Lock
 

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ kwargs = {
     "license": "Apache-2.0",
     "install_requires": [
         "clowncar",
-        "tornado>=3.2",
+        "tornado==4.5.3",
     ],
     "setup_requires": setup_requires,
     "tests_require": [


### PR DESCRIPTION
When Groupy is having issues connecting to one API server, it retries against the other servers. On ECONNREFUSED however (such as when a server is down entirely), it doesn't retry since it never catches the exception. Fix that by catching the exception appropriately.

Tested by trying to connect to a nonexistent server.