### PR TITLE
Use six instead of future, bump clowncar dependency

### DIFF
--- a/groupy/client.py
+++ b/groupy/client.py
@@ -6,18 +6,19 @@ from threading import Lock
 from typing import NamedTuple, TYPE_CHECKING
 
 from clowncar.backends import Backends
-from future import standard_library
 from tornado.httpclient import HTTPClient, HTTPError, HTTPRequest
 
 from groupy import exc
 from groupy.collations import Groups, Permissions, ServiceAccounts, Users
 
+try:
+    from urllib.parse import urlencode
+except ImportError:
+    from urllib import urlencode  # type: ignore
+
 if TYPE_CHECKING:
     from clowncar.server import Server
     from typing import Any, Dict, List, Optional
-
-standard_library.install_aliases()
-import urllib.parse  # noqa: E402, I100
 
 Checkpoint = NamedTuple("Checkpoint", [("checkpoint", int), ("checkpoint_time", float)])
 
@@ -134,6 +135,4 @@ class Groupy(object):
 
     def authenticate(self, token):
         # type: (str) -> Dict[str, Any]
-        return self._try_fetch(
-            "/token/validate", method="POST", body=urllib.parse.urlencode({"token": token})
-        )
+        return self._try_fetch("/token/validate", method="POST", body=urlencode({"token": token}))

--- a/groupy/resources.py
+++ b/groupy/resources.py
@@ -1,7 +1,6 @@
 from typing import TYPE_CHECKING
 
-from future.utils import iteritems
-from past.builtins import unicode
+from six import iteritems, string_types
 
 if TYPE_CHECKING:
     from typing import Any, Dict, List, Optional, Union
@@ -10,7 +9,7 @@ if TYPE_CHECKING:
 class ResourceDict(dict):
     def __call__(self, direct=False, roles=None):
         # type: (bool, Union[str, List[str]]) -> Dict[str, Any]
-        if isinstance(roles, str) or isinstance(roles, unicode):
+        if isinstance(roles, string_types):
             roles = [roles]
         new_dict = {}
         for key, value in iteritems(self):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-clowncar
-future==0.17.1
+clowncar>=0.2.0
+six==1.12.0
 tornado==4.5.3
 typing==3.6.4


### PR DESCRIPTION
future's handling of urllib introduces a ton of problems due to
the newstr and newbytes types.  Use a much simpler conditional
import and switch to six from future for supporting functions.

Depend on a new enough clowncar to get Python 3 support.