### PR TITLE
Update Groupy client to optionally support SSL

### DIFF
--- a/groupy/client.py
+++ b/groupy/client.py
@@ -63,7 +63,7 @@ class Groupy(object):
             use_ssl (int): whether to connect to backend servers using https
                 rather than http.
                 TODO(): use_ssl should default to True. It currently defaults
-                set to False solely to preserve backwards compatibility.
+                to False solely to preserve backwards compatibility.
         """
 
         self._lock = Lock()

--- a/groupy/client.py
+++ b/groupy/client.py
@@ -41,6 +41,7 @@ class Groupy(object):
         checkpoint_time=0,  # type: float
         mark_bad_timeout=60,  # type: int
         max_backend_tries=5,  # type: int
+        use_ssl=False,  # type: bool
     ):
         # type: (...) -> None
         """
@@ -59,6 +60,10 @@ class Groupy(object):
                 have been marked as dead
             max_backend_tries (int): number of backend servers to try before
                 giving up and raising a BackendConnectionError
+            use_ssl (int): whether to connect to backend servers using https
+                rather than http.
+                TODO(): use_ssl should default to True. It currently defaults
+                set to False solely to preserve backwards compatibility.
         """
 
         self._lock = Lock()
@@ -70,6 +75,7 @@ class Groupy(object):
         self.allow_time_travel = allow_time_travel
         self.mark_bad_timeout = mark_bad_timeout
         self.max_backend_tries = max_backend_tries
+        self.use_ssl = use_ssl
 
         self.users = Users(self, "users")
         self.groups = Groups(self, "groups")
@@ -94,8 +100,9 @@ class Groupy(object):
         # type: (str, **Any) -> Dict[str, Any]
         http_client = HTTPClient()
         server = self.backends.server
+        protocol = "https" if self.use_ssl else "http"
         url = HTTPRequest(
-            "http://{}:{}{}".format(server.hostname, server.port, path),
+            "{}://{}:{}{}".format(protocol, server.hostname, server.port, path),
             connect_timeout=self.timeout,
             request_timeout=self.timeout,
             **kwargs

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -5,3 +5,5 @@ mypy>=0.701
 pytest>=2.6
 pytest-runner
 mock>=2.0
+types-mock>=4.0.1
+types-six>=1.16.1


### PR DESCRIPTION
Ref https://github.com/dropbox/groupy/issues/10

Provides the (long-overdue) ability to have Groupy connect to backend servers over SSL.

Unfortunately does not make SSL the default, for the sake of preserving backwards compatibility.